### PR TITLE
Feature to support dockerless compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,21 @@ path = "src/lib.rs"
 
 [[bin]]
 name = "pchain_compile"
+path = "src/bin/main.rs"
 
 [dependencies]
 bollard = "0.14.0"
 clap = {version = "4.3.11", features = ["derive"]}
+cargo = "0.72.2"
 cargo_toml = "0.11.5"
 dunce = "1.0.2"
 faccess = "0.2.4"
 rand = "0.6.0"
 thiserror = "1.0.31"
 tokio = {version = "1.19", features = ["full"]}
-wasm-snip = "0.4.0"
+wasm-snip = "=0.4.0"
 futures-util = "0.3.28"
 flate2 = "1.0.26"
 tar = "0.4.38"
+wasm-opt = "=0.114.0"
+walrus = "=0.12"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@
 
 `pchain_compile` builds the source code in a docker environment. To know more about Docker and install it, refer to the [official instructions](https://docs.docker.com/get-docker/).
 
-## Build the Source Code 
+## Installation
+
+Prebuilt binaries can be downloaded from assets in Github [releases page](https://github.com/parallelchain-io/pchain-compile/releases). Alternatively, you can install by `cargo install` if Rust has been installed already.
+
+```sh
+cargo install pchain_compile
+```
+
+## Build the Source Code
 
 Suppose you have the source code of smart contract in the folder `contract` under your home directory. 
 
@@ -42,11 +50,14 @@ Explanation about the command and its arguments can be displayed by appending "h
 
 ## Toolchain
 
-`pchain_compile` utilizes a docker_image hosted on a public DockerHub repository of ParallelChain see [here](https://hub.docker.com/r/parallelchainlab/pchain_compile) for the build process. The docker image utilizes a toolchain whose components are shown below in the following table below:
-     
-|Toolchain Component | Utility
-|:---                | :--- |
-rustc                | Compiler for Rust. |
-wasm-snip (0.4.0) | WASM utility which removes functions that are never called at runtime. |   
-wasm-opt  (109)  | WASM utility to load WebAssembly in text format and run Binaryen IR passes to optimize its size. For more information on Binaryen IR see [here](http://webassembly.github.io/binaryen/). |
+`pchain_compile` utilizes a docker_image hosted on a public DockerHub repository of ParallelChain see [here](https://hub.docker.com/r/parallelchainlab/pchain_compile) for the build process. Required components include:
+- rustc: compiler for Rust.
+- wasm-snip: WASM utility which removes functions that are never called at runtime.
+- wasm-opt: WASM utility to load WebAssembly in text format and run Binaryen IR passes to optimize its size. For more information on Binaryen IR see [here](http://webassembly.github.io/binaryen/).
 
+The docker images utilize a toolchain whose versions of each component are shown in the following table:
+
+|Image Tag |rustc |wasm-snip |wasm-opt |
+|:---|:---|:---|:---|
+|0.4.2 |1.71.0 |0.4.0 |114 |
+|mainnet01 |1.66.1 |0.4.0 |109 |

--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -1,22 +1,16 @@
-FROM rust:1.66.1 as cache
-
-# Download binaryen sources
-ADD https://github.com/WebAssembly/binaryen/archive/refs/tags/version_110.tar.gz /tmp/binaryen.tar.gz
+FROM rust:1.71.0 as cache
 
 # Extract and compile wasm-opt & install wasm-snip
 RUN apt update && apt-get -y install wget && \
-    wget https://github.com/WebAssembly/binaryen/releases/download/version_109/binaryen-version_109-x86_64-linux.tar.gz && \
-    tar xzf binaryen-version_109-x86_64-linux.tar.gz && mv binaryen-version_109/bin/wasm-opt /usr/local/bin && \
-    rm -rf binaryen-version_109*
+    wget https://github.com/WebAssembly/binaryen/releases/download/version_114/binaryen-version_114-x86_64-linux.tar.gz && \
+    tar xzf binaryen-version_114-x86_64-linux.tar.gz && mv binaryen-version_114/bin/wasm-opt /usr/local/bin && \
+    rm -rf binaryen-version_114*
 
 # pchain-compile base image
-FROM rust:1.66.1 as base-image
+FROM rust:1.71.0 as base-image
 
 # Setup rust with wasm support
 RUN cargo install wasm-snip && rustup target add wasm32-unknown-unknown && mkdir -p /root/bin
-
-# Install cargo prefetch and cache some frequently used crates for faster builds 
-RUN cargo install cargo-prefetch && cargo prefetch --top-downloads=100
 
 # Add wasm-opt
 COPY --from=cache /usr/local/bin/wasm-opt /root/bin

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -41,7 +41,7 @@ enum PchainCompile {
         /// 
         /// To install target "wasm32-unknown-unkown", run the following command:
         ///
-        /// $ rustup add wasm32-unknown-unknown
+        /// $ rustup target add wasm32-unknown-unknown
         #[clap(
             long = "dockerless",
             display_order = 3,

--- a/src/build.rs
+++ b/src/build.rs
@@ -42,7 +42,7 @@ pub async fn build_target(
     build_target_with_docker(source_path, destination_path, DockerConfig::default()).await
 }
 
-/// Build target with use of docker.
+/// Validates inputs and trigger building process that uses docker.
 pub(crate) async fn build_target_with_docker(
     source_path: PathBuf,
     destination_path: Option<PathBuf>,
@@ -72,7 +72,7 @@ pub(crate) async fn build_target_with_docker(
     build_target_in_docker(source_path, destination_path, docker_image_tag, wasm_file).await
 }
 
-/// Build target without using docker.
+/// Validates inputs and trigger building process that does not use docker.
 pub(crate) async fn build_target_without_docker(
     source_path: PathBuf,
     destination_path: Option<PathBuf>,
@@ -100,7 +100,7 @@ fn validated_source_path(source_path: PathBuf) -> Result<PathBuf, Error> {
     Ok(Path::new(&src_absolute_str).to_path_buf())
 }
 
-/// Entry process for building contract with use of docker. It manages to pull docker image, start and remove containers.
+/// Setup docker environment and build contract in docker container. It manages to pull docker image, start and remove containers.
 async fn build_target_in_docker(
     source_path: PathBuf,
     destination_path: Option<PathBuf>,
@@ -134,7 +134,7 @@ async fn build_target_in_docker(
     result.map(|_| wasm_file)
 }
 
-/// Inner process for compiling contract in docker container. It does not remove docker container after use.
+/// Inner process in method [build_target_in_docker] to compile contract in docker container. It does not remove docker container after use.
 async fn compile_contract_in_docker_container(
     docker: &Docker,
     container_name: &str,
@@ -172,7 +172,7 @@ async fn compile_contract_in_docker_container(
     Ok(())
 }
 
-/// Entry process for building contract without using docker. It manages to create a temporary workding folder and 
+/// Setup filesystem and build contract by cargo. It manages to create a temporary workding folder and 
 /// remove it after call.
 async fn build_target_by_cargo(
     source_path: PathBuf,

--- a/src/build.rs
+++ b/src/build.rs
@@ -5,6 +5,8 @@
 
 //! Implementation of contracts compilation.
 //!
+//! ## Compilation with use of Docker
+//!
 //! The flow of the compilation process is as follows:
 //! 1. Setup destination folders and parse the command arguments into in-memory data that is to be used in subsequent steps.
 //!    Also pull the docker image from docker hub.
@@ -12,6 +14,15 @@
 //!    that are using relative paths in dependencies.
 //! 3. Compile the source code in the docker container. The dependencies (if any) are compile first.
 //! 4. After compilation, copy the binary (wasm) from docker container to target destination.
+//!
+//! ## Compilation without using Docker
+//!
+//! This way to compile smart contract requires the caller to install Rust and add target `wasm32-unknown-unknown` beforehand.
+//! The actual steps are as same as those commands executing inside the docker container. In simple words, build by `Cargo build`,
+//! then optimize and snip by `wasm-opt` and `wasm-snip`.
+//!
+//! **Please note the compiled contracts are not always consistent with the previous compiled ones, because the building process happens in
+//! your local changing environment.**
 
 use bollard::Docker;
 use std::path::Path;
@@ -20,10 +31,49 @@ use std::{collections::HashSet, path::PathBuf};
 use std::fs;
 
 use crate::error::Error;
+use crate::DockerConfig;
 
 /// `build_target` takes the path to the cargo manifest file(s), generates an optimized WASM binary(ies) after building
 /// the source code and saves the binary(ies) to the designated destination_path.
 pub async fn build_target(
+    source_path: PathBuf,
+    destination_path: Option<PathBuf>,
+) -> Result<String, Error> {
+    build_target_with_docker(source_path, destination_path, DockerConfig::default()).await
+}
+
+/// Build target with use of docker.
+pub(crate) async fn build_target_with_docker(
+    source_path: PathBuf,
+    destination_path: Option<PathBuf>,
+    docker_config: DockerConfig,
+) -> Result<String, Error> {
+    // create destination directory if it does not exist.
+    if let Some(dst_path) = &destination_path {
+        fs::create_dir_all(dst_path).map_err(|_| Error::InvalidDestinationPath)?;
+    }
+
+    // check validity of source path (and convert relative path to absolute path if applicable)
+    let source_path = validated_source_path(source_path)?;
+
+    // check if the manifest file exists on the path supplied.
+    let package_name =
+        crate::manifests::package_name(&source_path).map_err(|_| Error::InvalidSourcePath)?;
+    let wasm_file = format!("{package_name}.wasm").replace('-', "_");
+
+    // check if docker image tag is valid
+    let docker_image_tag = docker_config
+        .tag
+        .unwrap_or(crate::docker::PCHAIN_COMPILE_IMAGE_TAGS[0].to_string());
+    if !crate::docker::PCHAIN_COMPILE_IMAGE_TAGS.contains(&docker_image_tag.as_str()) {
+        return Err(Error::UnkownDockerImageTag(docker_image_tag));
+    }
+
+    build_target_in_docker(source_path, destination_path, docker_image_tag, wasm_file).await
+}
+
+/// Build target without using docker.
+pub(crate) async fn build_target_without_docker(
     source_path: PathBuf,
     destination_path: Option<PathBuf>,
 ) -> Result<String, Error> {
@@ -33,30 +83,42 @@ pub async fn build_target(
     }
 
     // check validity of source path (and convert relative path to absolute path if applicable)
-    let src_str = source_path
-        .to_str()
-        .ok_or(Error::InvalidSourcePath)?;
-    let src_absolute_str = crate::manifests::get_absolute_path(src_str)
-        .map_err(|_| Error::InvalidSourcePath)?;
-    let source_path = Path::new(&src_absolute_str).to_path_buf();
+    let source_path = validated_source_path(source_path)?;
 
     // check if the manifest file exists on the path supplied.
     let package_name =
         crate::manifests::package_name(&source_path).map_err(|_| Error::InvalidSourcePath)?;
     let wasm_file = format!("{package_name}.wasm").replace('-', "_");
 
-    // retrieve dependency paths from manifest.
+    build_target_by_cargo(source_path, destination_path, wasm_file).await
+}
+
+fn validated_source_path(source_path: PathBuf) -> Result<PathBuf, Error> {
+    let src_str = source_path.to_str().ok_or(Error::InvalidSourcePath)?;
+    let src_absolute_str =
+        crate::manifests::get_absolute_path(src_str).map_err(|_| Error::InvalidSourcePath)?;
+    Ok(Path::new(&src_absolute_str).to_path_buf())
+}
+
+/// Entry process for building contract with use of docker. It manages to pull docker image, start and remove containers.
+async fn build_target_in_docker(
+    source_path: PathBuf,
+    destination_path: Option<PathBuf>,
+    docker_image_tag: String,
+    wasm_file: String,
+) -> Result<String, Error> {
+    // Retrieve dependency paths from manifest.
     let mut dependencies = HashSet::new();
     crate::manifests::get_dependency_paths(&source_path, &mut dependencies)?;
 
+    // Create container from Parallelchain Lab docker image
     let container_name = crate::docker::random_container_name();
-
     let docker = Docker::connect_with_local_defaults().map_err(|_| Error::DockerDaemonFailure)?;
-    crate::docker::pull_image(&docker).await?;
-    crate::docker::start_container(&docker, &container_name).await?;
+    let image_name = crate::docker::pull_image(&docker, &docker_image_tag).await?;
+    crate::docker::start_container(&docker, &container_name, image_name).await?;
 
-    // Build Contract in docker container
-    let result = build_in_docker(
+    // Compile Contract in docker container
+    let result = compile_contract_in_docker_container(
         &docker,
         &container_name,
         dependencies,
@@ -72,7 +134,8 @@ pub async fn build_target(
     result.map(|_| wasm_file)
 }
 
-async fn build_in_docker(
+/// Inner process for compiling contract in docker container. It does not remove docker container after use.
+async fn compile_contract_in_docker_container(
     docker: &Docker,
     container_name: &str,
     dependencies: impl IntoIterator<Item = String>,
@@ -107,4 +170,29 @@ async fn build_in_docker(
     .await?;
 
     Ok(())
+}
+
+/// Entry process for building contract without using docker. It manages to create a temporary workding folder and 
+/// remove it after call.
+async fn build_target_by_cargo(
+    source_path: PathBuf,
+    destination_path: Option<PathBuf>,
+    wasm_file: String,
+) -> Result<String, Error> {
+    // 1. Create temporary folder as a working directory for cargo build
+    let temp_dir = crate::cargo::random_temp_dir_name();
+    std::fs::create_dir_all(temp_dir.as_path()).map_err(|_| Error::CreateTempDir)?;
+
+    // 2. Build the source code locally by cargo build
+    let result = crate::cargo::build_contract(
+        &temp_dir,
+        source_path.as_path(),
+        destination_path,
+        &wasm_file,
+    );
+
+    // 3. Remove temporary files after building
+    let _ = std::fs::remove_dir_all(temp_dir);
+
+    result.map(|_| wasm_file)
 }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -18,7 +18,7 @@ use crate::error::Error;
 
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
-/// Generate a random temporary director name
+/// Generate a random temporary directory name
 pub(crate) fn random_temp_dir_name() -> PathBuf {
     std::env::temp_dir()
         .join(
@@ -31,11 +31,11 @@ pub(crate) fn random_temp_dir_name() -> PathBuf {
         .to_path_buf()
 }
 
-/// Equivalent to perform following commands:
+/// Equivalent to running following commands:
 /// 1. cargo build --target wasm32-unknown-unknown --release --quiet
-/// 2. wasm-opt -Oz wasm_file --output temp.wasm
+/// 2. wasm-opt -Oz <wasm_file> --output temp.wasm
 /// 3. wasm-snip temp.wasm --output temp2.wasm --snip-rust-fmt-code --snip-rust-panicking-code
-/// 4. wasm-opt --dce temp2.wasm --output optimized.wasm
+/// 4. wasm-opt --dce temp2.wasm --output <wasm_file>
 pub(crate) fn build_contract(
     working_folder: &Path,
     source_path: &Path,
@@ -93,7 +93,7 @@ pub(crate) fn build_contract(
         .emit_wasm_file(&temp2_wasm)
         .map_err(|e| Error::BuildFailure(format!("Wasm snip error:\n\n{:?}\n", e)))?;
 
-    // 4. wasm-opt --dce temp2.wasm --output optimized.wasm
+    // 4. wasm-opt --dce temp2.wasm --output wasm_file
     let optimized_wasm = output_path.join(wasm_file);
     wasm_opt::OptimizationOptions::new_optimize_for_size()
         .add_pass(wasm_opt::Pass::Dce)

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,0 +1,104 @@
+/*
+    Copyright © 2023, ParallelChain Lab
+    Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+//! Implements the compilation process of smart contract by utilizing crates `cargo`, `wasm-opt` and `wasm-snip`.
+
+use std::path::{Path, PathBuf};
+
+use cargo::{
+    core::compiler::{CompileKind, CompileTarget},
+    ops::CompileOptions,
+    util::interning::InternedString,
+    Config,
+};
+
+use crate::error::Error;
+
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+
+/// Generate a random temporary director name
+pub(crate) fn random_temp_dir_name() -> PathBuf {
+    std::env::temp_dir()
+        .join(
+            thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(5)
+                .map(char::from)
+                .collect::<String>(),
+        )
+        .to_path_buf()
+}
+
+/// Equivalent to perform following commands:
+/// 1. cargo build --target wasm32-unknown-unknown --release --quiet
+/// 2. wasm-opt -Oz wasm_file --output temp.wasm
+/// 3. wasm-snip temp.wasm --output temp2.wasm --snip-rust-fmt-code --snip-rust-panicking-code
+/// 4. wasm-opt --dce temp2.wasm --output optimized.wasm
+pub(crate) fn build_contract(
+    working_folder: &Path,
+    source_path: &Path,
+    destination_path: Option<PathBuf>,
+    wasm_file: &str,
+) -> Result<(), Error> {
+    let output_path = destination_path.unwrap_or(Path::new(".").to_path_buf());
+
+    // 1. cargo build --target wasm32-unknown-unknown --release --quiet
+    let mut config = Config::default().unwrap();
+    config
+        .configure(0, true, None, false, false, false, &None, &[], &[])
+        .unwrap();
+    let mut compile_configs =
+        CompileOptions::new(&config, cargo::util::command_prelude::CompileMode::Build).unwrap();
+    compile_configs.build_config.requested_kinds = vec![CompileKind::Target(
+        CompileTarget::new("wasm32-unknown-unknown").unwrap(),
+    )];
+    compile_configs.build_config.requested_profile = InternedString::new("release");
+    let ws =
+        cargo::core::Workspace::new(&source_path.join("Cargo.toml"), &config).map_err(|e| {
+            Error::BuildFailure(
+                format!("Error in preparing workspace according to the manifest file in source path:\n\n{:?}\n", e),
+            )
+        })?;
+    cargo::ops::compile(&ws, &compile_configs)
+        .map_err(|e| Error::BuildFailure(format!("Error in cargo build:\n\n{:?}\n", e)))?;
+
+    // 2. wasm-opt -Oz wasm_file --output temp.wasm
+    let temp_wasm = working_folder.join("temp.wasm");
+    wasm_opt::OptimizationOptions::new_optimize_for_size_aggressively()
+        .run(
+            source_path
+                .join("target")
+                .join("wasm32-unknown-unknown")
+                .join("release")
+                .join(wasm_file),
+            &temp_wasm,
+        )
+        .map_err(|e| Error::BuildFailure(format!("Wasm optimization error:\n\n{:?}\n", e)))?;
+
+    // 3. wasm-snip temp.wasm --output temp2.wasm --snip-rust-fmt-code --snip-rust-panicking-code
+    let temp2_wasm = working_folder.join("temp2.wasm");
+    let wasm_snip_options = wasm_snip::Options {
+        snip_rust_fmt_code: true,
+        snip_rust_panicking_code: true,
+        ..Default::default()
+    };
+    let mut module = walrus::ModuleConfig::new()
+        .parse_file(temp_wasm)
+        .map_err(|e| Error::BuildFailure(format!("Wasm snip error:\n\n{:?}\n", e)))?;
+    wasm_snip::snip(&mut module, wasm_snip_options)
+        .map_err(|e| Error::BuildFailure(format!("Wasm snip error:\n\n{:?}\n", e)))?;
+    module
+        .emit_wasm_file(&temp2_wasm)
+        .map_err(|e| Error::BuildFailure(format!("Wasm snip error:\n\n{:?}\n", e)))?;
+
+    // 4. wasm-opt --dce temp2.wasm --output optimized.wasm
+    let optimized_wasm = output_path.join(wasm_file);
+    wasm_opt::OptimizationOptions::new_optimize_for_size()
+        .add_pass(wasm_opt::Pass::Dce)
+        .run(temp2_wasm, optimized_wasm)
+        .map_err(|e| Error::BuildFailure(format!("Wasm optimization error:\n\n{:?}\n", e)))?;
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@
 */
 
 //! Configuration of pchain_compile. The struct `Config` specifies parameters being used, and
-//! provide a method `run` to start the compilation process.
+//! provides a method `run` that starts the compilation process.
 
 use std::path::PathBuf;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,62 @@
+/*
+    Copyright © 2023, ParallelChain Lab
+    Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+//! Configuration of pchain_compile. The struct `Config` specifies parameters being used, and
+//! provide a method `run` to start the compilation process.
+
+use std::path::PathBuf;
+
+use crate::error::Error;
+
+/// Configuration to compile smart contract.
+#[derive(Clone, Default)]
+pub struct Config {
+    /// Path to source code folder.
+    pub source_path: PathBuf,
+    /// Path to destination folder. None if current folder should be used.
+    pub destination_path: Option<PathBuf>,
+    /// Compilation option regards to use of docker.
+    pub docker_option: DockerOption,
+}
+
+/// Compilation option regards to docker.
+#[derive(Clone)]
+pub enum DockerOption {
+    /// Compile contract in docker container. (Default)
+    Docker(DockerConfig),
+    /// Compile contract without using Docker.
+    Dockerless,
+}
+
+impl Default for DockerOption {
+    fn default() -> Self {
+        Self::Docker(DockerConfig::default())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct DockerConfig {
+    /// Docker Image tag.
+    pub tag: Option<String>,
+}
+
+impl Config {
+    pub async fn run(self) -> Result<String, Error> {
+        match self.docker_option {
+            DockerOption::Docker(docker_config) => {
+                crate::build::build_target_with_docker(
+                    self.source_path,
+                    self.destination_path,
+                    docker_config,
+                )
+                .await
+            }
+            DockerOption::Dockerless => {
+                crate::build::build_target_without_docker(self.source_path, self.destination_path)
+                    .await
+            }
+        }
+    }
+}

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -32,7 +32,9 @@ use std::fs::File;
 use crate::error::Error;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
+/// List of docker image tags that can be used. 
 pub(crate) const PCHAIN_COMPILE_IMAGE_TAGS: [&str; 2] = ["mainnet01", env!("CARGO_PKG_VERSION")];
+/// The repo name in Parallelchain Lab Dockerhub: https://hub.docker.com/r/parallelchainlab/pchain_compile
 pub(crate) const PCHAIN_COMPILE_IMAGE: &str = "parallelchainlab/pchain_compile";
 
 /// Generate a random Docker container name
@@ -44,7 +46,7 @@ pub fn random_container_name() -> String {
         .collect()
 }
 
-/// Pull docker image from ParallelChain Lab DockerHub
+/// Pull docker image from ParallelChain Lab DockerHub. Returns the name of docker image.
 pub async fn pull_image(docker: &Docker, tag: &str) -> Result<String, Error> {
     let from_image = format!("{PCHAIN_COMPILE_IMAGE}:{tag}");
     let create_image_infos = &docker
@@ -67,7 +69,7 @@ pub async fn pull_image(docker: &Docker, tag: &str) -> Result<String, Error> {
     Ok(from_image)
 }
 
-/// Start containter with the Image pulled from ParallelChain Lab DockerHub
+/// Starts a containter with the Image pulled from ParallelChain Lab DockerHub
 pub async fn start_container(
     docker: &Docker,
     container_name: &str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,18 +30,26 @@ pub enum Error {
 
     #[error("Dependency path not valid.")]
     InvalidDependencyPath,
+
+    #[error("Fails to create temporary directory.")]
+    CreateTempDir,
+
+    #[error("Unknown docker image tag")]
+    UnkownDockerImageTag(String),
 }
 
 impl Error {
     pub fn detail(&self) -> String {
         match self {
             Error::ArtifactRemovalFailure => "The compilation was successful, but pchain-compile failed to stop its Docker containers. Please remove them manually.".to_string(), 
-            Error::BuildFailure(e) => format!("\nDetails: {}\nPlease rectify the errors and build your source code again.", &e),
+            Error::BuildFailure(e) => format!("\nDetails: {e}\nPlease rectify the errors and build your source code again."),
             Error::DockerDaemonFailure => "Failed to compile.\nDetails: Docker Daemon Failure. Check if Docker is running on your machine and confirm read/write access privileges.".to_string(),
             Error::ManifestFailure => "Failed to compile.\nDetails: Manifest File Not Found. Check if the manifest file exists on the source code path.".to_string(),
             Error::InvalidSourcePath => "Failed to compile.\nDetails: Source Code Path Not Valid. Check if you have provided the correct path to your source code directory and confirm write access privileges.".to_string(),
             Error::InvalidDestinationPath => "\nDetails: Destination Path Not Valid. Check if you have provided the correct path to save your optimized WASM binary and confirm write access privileges.".to_string(),
             Error::InvalidDependencyPath => "\nDetails: Dependency Paths specified within Smart Contract Crate Not Valid. Check if you have provided the correct path to the dependencies on your source".to_string(),
+            Error::CreateTempDir => "\nDetails: The compilation process requires creating a temporary folder in your machine. Please check if the program has write permission to create folder.".to_string(),
+            Error::UnkownDockerImageTag(tag) => format!("\nDetails: The docker image tag ({tag}) is not recognised. Please choose tag from dockerhub https://hub.docker.com/r/parallelchainlab/pchain_compile"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,7 +47,7 @@ impl Error {
             Error::ManifestFailure => "Failed to compile.\nDetails: Manifest File Not Found. Check if the manifest file exists on the source code path.".to_string(),
             Error::InvalidSourcePath => "Failed to compile.\nDetails: Source Code Path Not Valid. Check if you have provided the correct path to your source code directory and confirm write access privileges.".to_string(),
             Error::InvalidDestinationPath => "\nDetails: Destination Path Not Valid. Check if you have provided the correct path to save your optimized WASM binary and confirm write access privileges.".to_string(),
-            Error::InvalidDependencyPath => "\nDetails: Dependency Paths specified within Smart Contract Crate Not Valid. Check if you have provided the correct path to the dependencies on your source".to_string(),
+            Error::InvalidDependencyPath => "\nDetails: Dependency Paths Specified Within Smart Contract Crate Not Valid. Check if you have provided the correct path to the dependencies on your source".to_string(),
             Error::CreateTempDir => "\nDetails: The compilation process requires creating a temporary folder in your machine. Please check if the program has write permission to create folder.".to_string(),
             Error::UnkownDockerImageTag(tag) => format!("\nDetails: The docker image tag ({tag}) is not recognised. Please choose tag from dockerhub https://hub.docker.com/r/parallelchainlab/pchain_compile"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,30 @@
 */
 
 //! `pchain_compile` is a library to build ParallelChain Smart Contract that can be deployed to
-//! ParallelChain Mainnet. It takes a ParallelChain Smart Contract  written in Rust and builds by
+//! ParallelChain Mainnet. It takes a ParallelChain Smart Contract written in Rust and builds by
 //! Cargo in a docker environment.
-//! 
+//!
 //! # Example
 //! ```no_run
 //! let source_path = Path::new("/home/user/contract").to_path_buf();
 //! let result = pchain_compile::build_target(source_path, None).await;
 //! ```
+//! 
+//! # Example - Run from a configuration
+//! ```no_run
+//! let result = pchain_compile::Config {
+//!     source_path: Path::new("/home/user/contract").to_path_buf(),
+//!     docker_option: pchain_compile::DockerOption::Dockerless,
+//!     ..Default::default()
+//! }
+//! .run()
+//! .await;
+//! ```
+
+pub(crate) mod cargo;
+
+pub mod config;
+pub use config::*;
 
 pub(crate) mod docker;
 
@@ -19,5 +35,5 @@ pub mod error;
 
 pub(crate) mod manifests;
 
-mod build;
+pub mod build;
 pub use build::build_target;

--- a/src/manifests.rs
+++ b/src/manifests.rs
@@ -5,10 +5,7 @@
 
 //! Implements methods to obtain manifests of the contract and its dependencies.
 
-use std::{
-    collections::HashSet,
-    path::Path,
-};
+use std::{collections::HashSet, path::Path};
 
 use cargo_toml::{DependencyDetail, Manifest};
 use faccess::{AccessMode, PathExt};
@@ -24,7 +21,11 @@ pub fn get_dependency_paths(
         Manifest::from_path(source_path.join("Cargo.toml")).map_err(|_| Error::ManifestFailure)?;
 
     for dependency in source_manifest.dependencies.values() {
-        if let Some(DependencyDetail { path: Some(current_path), .. }) = dependency.detail() {
+        if let Some(DependencyDetail {
+            path: Some(current_path),
+            ..
+        }) = dependency.detail()
+        {
             let derived_path = get_absolute_path(current_path).unwrap_or(get_absolute_path(
                 source_path.join(current_path).as_os_str().to_str().unwrap(),
             )?);
@@ -32,8 +33,7 @@ pub fn get_dependency_paths(
             if !dependencies.contains(&derived_path) {
                 dependencies.insert(derived_path.clone());
                 // SAFETY: recursive call can be very deep
-                let _ =
-                    get_dependency_paths(Path::new(&derived_path), dependencies);
+                let _ = get_dependency_paths(Path::new(&derived_path), dependencies);
             }
         }
     }
@@ -51,12 +51,13 @@ pub fn package_name(current_dir: &Path) -> Result<String, Error> {
 /// Returns absolute path for a current directory.
 pub fn get_absolute_path(current_dir: &str) -> Result<String, Error> {
     // get canonicalized path to the directory.
-    let canonicalized_path = dunce::canonicalize(current_dir)
-        .map_err(|_| Error::InvalidDependencyPath)?;
+    let canonicalized_path =
+        dunce::canonicalize(current_dir).map_err(|_| Error::InvalidDependencyPath)?;
 
     // also check if pchain-compile has write privileges to the canonicalized path.
     // if check passes, get absolute path to the directory.
-    canonicalized_path.access(AccessMode::WRITE)
-    .map(|_| String::from(canonicalized_path.to_string_lossy()))
-    .map_err(|_| Error::InvalidDependencyPath)
+    canonicalized_path
+        .access(AccessMode::WRITE)
+        .map(|_| String::from(canonicalized_path.to_string_lossy()))
+        .map_err(|_| Error::InvalidDependencyPath)
 }

--- a/src/manifests.rs
+++ b/src/manifests.rs
@@ -48,14 +48,14 @@ pub fn package_name(current_dir: &Path) -> Result<String, Error> {
         .map_err(|_| Error::ManifestFailure)
 }
 
-/// Returns absolute path for a current directory.
-pub fn get_absolute_path(current_dir: &str) -> Result<String, Error> {
-    // get canonicalized path to the directory.
+/// Returns absolute path of a directory.
+pub fn get_absolute_path(dir: &str) -> Result<String, Error> {
+    // get canonicalized path of the directory.
     let canonicalized_path =
-        dunce::canonicalize(current_dir).map_err(|_| Error::InvalidDependencyPath)?;
+        dunce::canonicalize(dir).map_err(|_| Error::InvalidDependencyPath)?;
 
     // also check if pchain-compile has write privileges to the canonicalized path.
-    // if check passes, get absolute path to the directory.
+    // if check passes, get absolute path of the directory.
     canonicalized_path
         .access(AccessMode::WRITE)
         .map(|_| String::from(canonicalized_path.to_string_lossy()))


### PR DESCRIPTION
It is merge request mainly for resolving issue (#6) which is to allow pchain_compile to compile contract without using docker.

Features:
- compile contract without using docker
- add command line option to specify the tag of docker image

Refactor: 
- provide struct Config as compilation configuration 