### PR TITLE
Update docker image tag to 0.4.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
   RELEASE_DIR: artifacts
   GITHUB_REF: '${{ github.ref }}'
   WINDOWS_TARGET: x86_64-pc-windows-msvc
-  MACOS_TARGET: x86_64-apple-darwin
+  MACOS_TARGET: aarch64-apple-darwin
   LINUX_TARGET: x86_64-unknown-linux-gnu
 
 jobs:
@@ -23,8 +23,8 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
             rust: stable
-          - target: x86_64-apple-darwin
-            os: macos-12
+          - target: aarch64-apple-darwin
+            os: macos-14
             rust: stable
           - target: x86_64-pc-windows-msvc
             os: windows-2022
@@ -44,7 +44,7 @@ jobs:
           echo ::set-output name=version::"${GITHUB_REF:10}"
       
       - name: Install p7zip (MacOS)
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-14'
         run: brew install p7zip
       
       - name: Add rustup target
@@ -63,7 +63,7 @@ jobs:
           mkdir -p ${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}
       
       - name: Move binaries (Linux/MacOS)
-        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-12'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-14'
         run: |
           mv ./target/${{ matrix.target }}/release/${{ env.RELEASE_BIN }} ${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}/${{ env.RELEASE_BIN }}
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             rust: stable
           - target: x86_64-apple-darwin
             os: macos-12
@@ -63,7 +63,7 @@ jobs:
           mkdir -p ${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}
       
       - name: Move binaries (Linux/MacOS)
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-12'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-12'
         run: |
           mv ./target/${{ matrix.target }}/release/${{ env.RELEASE_BIN }} ${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}/${{ env.RELEASE_BIN }}
       

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pchain_compile"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["ParallelChain Lab <info@parallelchain.io>"]
 edition = "2021"
 description = "ParallelChain Smart Contract Compile CLI - A command line tool for compiling ParallelChain Smart Contract."

--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # ParallelChain Mainnet Contract Compiler (pchain_compile) 
 
-`pchain_compile` is a command line tool for reproducibly building Rust code into compact, gas-efficient WebAssembly [ParallelChain Mainnet Smart Contracts](https://github.com/parallelchain-io/parallelchain-protocol/blob/master/Contracts.md).
+`pchain_compile` is a command line tool for reproducibly building [Rust](https://www.rust-lang.org/) code into compact, gas-efficient WebAssembly [ParallelChain Mainnet Smart Contracts](https://github.com/parallelchain-io/parallelchain-protocol/blob/master/Contracts.md).
 
 ## Pre-Requisites
 
-`pchain_compile` builds the source code in a docker environment. To know more about Docker and install it, refer to the [official instructions](https://docs.docker.com/get-docker/).
+`pchain_compile` compiles the ParallelChain smart contract code in Rust into contract binary in WebAssembly. To know more about developing ParallelChain smart contracts, visit [ParallelChain Mainnet Contract SDK](https://crates.io/crates/pchain-sdk).
+
+By default, the compiler requires **docker** to be installed in your local machine. In detail, it pulls the [Docker Image](#about-docker-image) from DockerHub, and starts a docker container which provides a complete environment for building WebAssembly binary. To install docker, follow the instructions in [Docker Docs](https://docs.docker.com/get-docker/).
 
 ## Installation
 
-Prebuilt binaries can be downloaded from assets in Github [releases page](https://github.com/parallelchain-io/pchain-compile/releases). Alternatively, you can install by `cargo install` if Rust has been installed already.
+
+Download prebuilt executables from the Github [Releases page](https://github.com/parallelchain-io/pchain-compile/releases). 
+
+Alternatively, you can install the binary crate [pchain_compile](https://crates.io/crates/pchain_compile) by [cargo install](https://doc.rust-lang.org/cargo/commands/cargo-install.html) if Rust has been installed already.
 
 ```sh
 cargo install pchain_compile
 ```
 
-## Build the Source Code
+## Build Smart Contract
 
-Suppose you have the source code of smart contract in the folder `contract` under your home directory. 
+Let say your smart contract source code is in the folder `contract` under your home directory. 
 
 ```text
 /home/
@@ -27,18 +32,23 @@ Suppose you have the source code of smart contract in the folder `contract` unde
       |- Cargo.toml
 ```
 
-To build smart contract into WebAssembly bytecode (file extension `.wasm`), you can simply run the program by specifying the arguments **source** and **destination**.
+Run `pchain_compile` with the arguments **source** and **destination** to specify the folder of the source code and the folder for saving the result.
 
-On a Linux Bash Shell:
-      
 ```sh
-$ ./pchain_compile build --source /home/user/contract --destination /home/user/result
+pchain_compile build --source /home/user/contract --destination /home/user/result
+```
+
+Once complete, the console displays message:
+
+```text
 Build process started. This could take several minutes for large contracts.
 
 Finished compiling. ParallelChain Mainnet smart contract(s) ["contract.wasm"] are saved at (/home/user/result).
 ```
 
-On a Windows Shell:
+Your WebAssembly smart contract is now saved with file extension `.wasm` at the destination folder. 
+
+If you are running on Windows, here is the example output:
 ```powershell
 $ .\pchain_compile.exe build --source 'C:\Users\user\contract' --destination 'C:\Users\user\result'
 Build process started. This could take several minutes for large contracts.
@@ -46,19 +56,27 @@ Build process started. This could take several minutes for large contracts.
 Finished compiling. ParallelChain Mainnet smart contract(s) ["contract.wasm"] are saved at (C:\Users\user\result).
 ```
 
-Explanation about the command and its arguments can be displayed by appending "help" or "--help" to `pchain_compile`.
+To understand more about the commands and arguments, run `pchain_compile build --help`.
 
-## Toolchain
+## About Docker Image
 
-`pchain_compile` utilizes a docker_image hosted on a public DockerHub repository of ParallelChain see [here](https://hub.docker.com/r/parallelchainlab/pchain_compile) for the build process. Required components include:
+`pchain_compile` pulls docker image from ParallelChain Lab's official DockerHub [repository](https://hub.docker.com/r/parallelchainlab/pchain_compile) for the build process. The docker image provides an environment with installed components:
 - rustc: compiler for Rust.
 - wasm-snip: WASM utility which removes functions that are never called at runtime.
 - wasm-opt: WASM utility to load WebAssembly in text format and run Binaryen IR passes to optimize its size. For more information on Binaryen IR see [here](http://webassembly.github.io/binaryen/).
 
-The docker images utilize a toolchain whose versions of each component are shown in the following table:
+There are different tags of the docker image. They vary on the versions of the components. The table below describes the tags and their differences.
 
 |Image Tag |rustc |wasm-snip |wasm-opt |
 |:---|:---|:---|:---|
 |0.4.3 | 1.77.1 | 0.4.0| 114|
 |0.4.2 | 1.71.0 | 0.4.0 | 114 |
 |mainnet01 | 1.66.1 | 0.4.0 | 109 |
+
+To build smart contract in a specific docker environment, run with argument **--user-docker-tag**. For example,
+
+```sh
+pchain_compile build --source /home/user/contract --destination /home/user/result --use-docker-tag 0.4.3
+```
+
+If **--user-docker-tag** is not used, the tag being used is with the same version as `pchain_compile`.

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ There are different tags of the docker image. They vary on the versions of the c
 |0.4.2 | 1.71.0 | 0.4.0 | 114 |
 |mainnet01 | 1.66.1 | 0.4.0 | 109 |
 
-To build smart contract in a specific docker environment, run with argument **--user-docker-tag**. For example,
+To build smart contract in a specific docker environment, run with argument **use-docker-tag**. For example,
 
 ```sh
 pchain_compile build --source /home/user/contract --destination /home/user/result --use-docker-tag 0.4.3
 ```
 
-If **--user-docker-tag** is not used, the tag being used is with the same version as `pchain_compile`.
+If **use-docker-tag** is not used, the tag being used is with the same version as `pchain_compile`.

--- a/README.md
+++ b/README.md
@@ -59,5 +59,6 @@ The docker images utilize a toolchain whose versions of each component are shown
 
 |Image Tag |rustc |wasm-snip |wasm-opt |
 |:---|:---|:---|:---|
-|0.4.2 |1.71.0 |0.4.0 |114 |
-|mainnet01 |1.66.1 |0.4.0 |109 |
+|0.4.3 | 1.77.1 | 0.4.0| 114|
+|0.4.2 | 1.71.0 | 0.4.0 | 114 |
+|mainnet01 | 1.66.1 | 0.4.0 | 109 |

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Pre-Requisites
 
-`pchain_compile` compiles the ParallelChain smart contract code in Rust into contract binary in WebAssembly. To know more about developing ParallelChain smart contracts, visit [ParallelChain Mainnet Contract SDK](https://crates.io/crates/pchain-sdk).
+`pchain_compile` compiles the ParallelChain smart contract code from Rust into a WebAssembly binary. To know more about developing ParallelChain smart contracts, visit [ParallelChain Mainnet Contract SDK](https://crates.io/crates/pchain-sdk).
 
-By default, the compiler requires **docker** to be installed in your local machine. In detail, it pulls the [Docker Image](#about-docker-image) from DockerHub, and starts a docker container which provides a complete environment for building WebAssembly binary. To install docker, follow the instructions in [Docker Docs](https://docs.docker.com/get-docker/).
+By default, the compiler requires **docker** to be installed in your local machine. In detail, it pulls the [Docker Image](#using-the-pchain_compile-docker-image) from DockerHub, and starts a docker container which provides a complete environment for building WebAssembly binary. To install docker, follow the instructions in [Docker Docs](https://docs.docker.com/get-docker/).
 
 ## Installation
 
@@ -21,7 +21,7 @@ cargo install pchain_compile
 
 ## Build Smart Contract
 
-Let say your smart contract source code is in the folder `contract` under your home directory. 
+Let's say your smart contract source code is in the folder `contract` under your home directory. 
 
 ```text
 /home/
@@ -58,9 +58,9 @@ Finished compiling. ParallelChain Mainnet smart contract(s) ["contract.wasm"] ar
 
 To understand more about the commands and arguments, run `pchain_compile build --help`.
 
-## About Docker Image
+## Using The `pchain_compile` Docker Image
 
-`pchain_compile` pulls docker image from ParallelChain Lab's official DockerHub [repository](https://hub.docker.com/r/parallelchainlab/pchain_compile) for the build process. The docker image provides an environment with installed components:
+`pchain_compile` pulls a docker image from ParallelChain Lab's official DockerHub [repository](https://hub.docker.com/r/parallelchainlab/pchain_compile) for the build process. The docker image provides an environment with installed components:
 - rustc: compiler for Rust.
 - wasm-snip: WASM utility which removes functions that are never called at runtime.
 - wasm-opt: WASM utility to load WebAssembly in text format and run Binaryen IR passes to optimize its size. For more information on Binaryen IR see [here](http://webassembly.github.io/binaryen/).
@@ -73,10 +73,10 @@ There are different tags of the docker image. They vary on the versions of the c
 |0.4.2 | 1.71.0 | 0.4.0 | 114 |
 |mainnet01 | 1.66.1 | 0.4.0 | 109 |
 
-To build smart contract in a specific docker environment, run with argument **use-docker-tag**. For example,
+To build a smart contract in a specific docker environment, run with argument **use-docker-tag**. For example,
 
 ```sh
 pchain_compile build --source /home/user/contract --destination /home/user/result --use-docker-tag 0.4.3
 ```
 
-If **use-docker-tag** is not used, the tag being used is with the same version as `pchain_compile`.
+If **use-docker-tag** is not used, the docker image tag is determined by the version of `pchain_compile`. For example, `pchain_compile` v0.4.3 will pull the docker image with tag `0.4.3`.

--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.71.0 as cache
+FROM rust:1.77.1 as cache
 
 # Extract and compile wasm-opt & install wasm-snip
 RUN apt update && apt-get -y install wget && \
@@ -7,7 +7,7 @@ RUN apt update && apt-get -y install wget && \
     rm -rf binaryen-version_114*
 
 # pchain-compile base image
-FROM rust:1.71.0 as base-image
+FROM rust:1.77.1 as base-image
 
 # Setup rust with wasm support
 RUN cargo install wasm-snip && rustup target add wasm32-unknown-unknown && mkdir -p /root/bin

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -66,6 +66,7 @@ enum PchainCompile {
         /// Available tags:
         /// - mainnet01
         /// - 0.4.2
+        /// - 0.4.3
         #[clap(
             long = "use-docker-tag",
             display_order = 5,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -61,10 +61,7 @@ pub async fn pull_image(docker: &Docker, tag: &str) -> Result<String, Error> {
         )
         .try_collect::<Vec<_>>()
         .await
-        .map_err(|e| {
-            println!("{e:?}");
-            Error::DockerDaemonFailure
-})?;
+        .map_err(|_| Error::DockerDaemonFailure)?;
 
     if create_image_infos.is_empty() || create_image_infos.first().unwrap().error.is_some() {
         return Err(Error::DockerDaemonFailure);

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -33,7 +33,7 @@ use crate::error::Error;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
 /// List of docker image tags that can be used. The first (0-indexed) is the default one. 
-pub(crate) const PCHAIN_COMPILE_IMAGE_TAGS: [&str; 2] = [env!("CARGO_PKG_VERSION"), "mainnet01"];
+pub(crate) const PCHAIN_COMPILE_IMAGE_TAGS: [&str; 3] = [env!("CARGO_PKG_VERSION"), "0.4.2", "mainnet01"];
 /// The repo name in Parallelchain Lab Dockerhub: https://hub.docker.com/r/parallelchainlab/pchain_compile
 pub(crate) const PCHAIN_COMPILE_IMAGE: &str = "parallelchainlab/pchain_compile";
 const DOCKER_EXEC_TIME_LIMIT: u64 = 15; // secs. It is a time limit to normal docker execution (except cargo build).
@@ -61,7 +61,10 @@ pub async fn pull_image(docker: &Docker, tag: &str) -> Result<String, Error> {
         )
         .try_collect::<Vec<_>>()
         .await
-        .map_err(|_| Error::DockerDaemonFailure)?;
+        .map_err(|e| {
+            println!("{e:?}");
+            Error::DockerDaemonFailure
+})?;
 
     if create_image_infos.is_empty() || create_image_infos.first().unwrap().error.is_some() {
         return Err(Error::DockerDaemonFailure);


### PR DESCRIPTION
In this PR, `pchain_compile` is modified to use the latest docker image (tag `0.4.3`) from the repo in dockerhub. This version of docker image installs the latest rust stable version 1.77.1. 

Other changes:
- update release.yml to build release in ubuntu 22.04 instead of 20.04.
- update release.yml to build release in macOS-14 instead of macOS-12.
- update README file.